### PR TITLE
Run bugbot

### DIFF
--- a/docker-compose.mt5.yml
+++ b/docker-compose.mt5.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+services:
+  mt5:
+    build:
+      context: ./infra/mt5
+    platform: linux/amd64
+    environment:
+      - WINEARCH=win64
+      - WINEPREFIX=/data/wine
+      - DISPLAY=:99
+      - TZ=${TZ:-UTC}
+      - MT5_INSTALL_DIR=/opt/mt5
+      - MT5_DATA_DIR=/opt/mt5_data
+    volumes:
+      - mt5_install:/opt/mt5
+      - mt5_data:/opt/mt5_data
+      - wine_prefix:/data/wine
+    restart: unless-stopped
+
+volumes:
+  mt5_install:
+  mt5_data:
+  wine_prefix:

--- a/docs/mt5-setup.md
+++ b/docs/mt5-setup.md
@@ -1,0 +1,51 @@
+# MetaTrader 5 Container (Wine)
+
+This container bakes a recent MetaTrader 5 (MT5) build during image build and runs MT5 in portable mode with persistent volumes so updates survive restarts.
+
+## Build
+
+```bash
+docker build -t mt5:latest -f infra/mt5/Dockerfile .
+```
+
+Or with Compose:
+
+```bash
+docker compose -f docker-compose.mt5.yml build
+```
+
+## Run (Apple Silicon friendly)
+
+```bash
+docker compose -f docker-compose.mt5.yml up -d
+```
+
+Notes:
+- On Apple Silicon, this service enforces `platform: linux/amd64` to run under emulation.
+- Volumes persist installation (`/opt/mt5`), data (`/opt/mt5_data`), and the Wine prefix (`/data/wine`).
+
+## Verify
+
+- Check logs to confirm MT5 started and remains healthy:
+  ```bash
+  docker compose -f docker-compose.mt5.yml logs -f mt5
+  ```
+- Verify the process is running in the container:
+  ```bash
+  docker exec -it $(docker compose -f docker-compose.mt5.yml ps -q mt5) bash -lc "pgrep -fa 'terminal(64)?\.exe'"
+  ```
+
+## Updates
+
+- The image bakes a recent installer. MT5 may still self-update at runtime. Because install/data are stored in volumes, updates persist across restarts.
+- To rebake to the newest MT5 build, rebuild the image:
+  ```bash
+  docker compose -f docker-compose.mt5.yml build --no-cache
+  docker compose -f docker-compose.mt5.yml up -d --force-recreate
+  ```
+
+## Troubleshooting
+
+- If MT5 fails to start, ensure volumes are writable and the host has sufficient memory/CPU.
+- Time sync matters. On macOS, ensure system clock is correct. Inside container, you can set `TZ` env if needed.
+- If the install volume is empty on first boot, it will be hydrated from the baked copy.

--- a/infra/mt5/Dockerfile
+++ b/infra/mt5/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+ARG DEBIAN_FRONTEND=noninteractive
+FROM debian:bookworm-slim
+
+RUN dpkg --add-architecture i386 \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		wine64 wine32 winbind xvfb cabextract wget unzip ca-certificates tzdata xauth procps \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV WINEARCH=win64
+ENV WINEPREFIX=/data/wine
+ENV DISPLAY=:99
+ENV MT5_INSTALL_DIR=/opt/mt5
+ENV MT5_DATA_DIR=/opt/mt5_data
+
+RUN mkdir -p "$MT5_INSTALL_DIR" "$MT5_DATA_DIR" "$WINEPREFIX"
+
+COPY install_mt5.sh /usr/local/bin/install_mt5.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/install_mt5.sh /usr/local/bin/entrypoint.sh \
+	&& /usr/local/bin/install_mt5.sh
+
+# Seed a baked copy to rehydrate runtime volumes on first start
+RUN mkdir -p /opt/mt5_baked \
+	&& if [ -d "$WINEPREFIX/drive_c/Program Files/MetaTrader 5" ]; then \
+		cp -a "$WINEPREFIX/drive_c/Program Files/MetaTrader 5/." /opt/mt5_baked/; \
+	elif [ -d "$WINEPREFIX/drive_c/Program Files/MetaTrader 5 Trading Platform" ]; then \
+		cp -a "$WINEPREFIX/drive_c/Program Files/MetaTrader 5 Trading Platform/." /opt/mt5_baked/; \
+	fi
+
+VOLUME ["/opt/mt5", "/opt/mt5_data", "/data/wine"]
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s CMD pgrep -fa 'terminal(64)?\\.exe' >/dev/null || exit 1
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/infra/mt5/entrypoint.sh
+++ b/infra/mt5/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${WINEPREFIX:=/data/wine}"
+: "${WINEARCH:=win64}"
+: "${DISPLAY:=:99}"
+: "${MT5_INSTALL_DIR:=/opt/mt5}"
+: "${MT5_DATA_DIR:=/opt/mt5_data}"
+
+# Start Xvfb if not already running
+if ! pgrep -f "Xvfb ${DISPLAY}" >/dev/null 2>&1; then
+	rm -f /tmp/.X99-lock || true
+	Xvfb "${DISPLAY}" -screen 0 1280x800x24 -ac +extension GLX +render -noreset &
+fi
+
+sleep 1
+
+# Hydrate install volume on first run
+if [ -z "$(ls -A "${MT5_INSTALL_DIR}" 2>/dev/null)" ] && [ -d /opt/mt5_baked ]; then
+	cp -a /opt/mt5_baked/. "${MT5_INSTALL_DIR}/"
+fi
+
+# Determine executable path
+EXE=""
+if [ -f "${MT5_INSTALL_DIR}/terminal64.exe" ]; then
+	EXE="${MT5_INSTALL_DIR}/terminal64.exe"
+elif [ -f "${MT5_INSTALL_DIR}/terminal.exe" ]; then
+	EXE="${MT5_INSTALL_DIR}/terminal.exe"
+else
+	if [ -f "${WINEPREFIX}/drive_c/Program Files/MetaTrader 5/terminal64.exe" ]; then
+		EXE="${WINEPREFIX}/drive_c/Program Files/MetaTrader 5/terminal64.exe"
+	elif [ -f "${WINEPREFIX}/drive_c/Program Files/MetaTrader 5 Trading Platform/terminal64.exe" ]; then
+		EXE="${WINEPREFIX}/drive_c/Program Files/MetaTrader 5 Trading Platform/terminal64.exe"
+	fi
+fi
+
+if [ -z "${EXE}" ]; then
+	echo "[entrypoint] MT5 executable not found" >&2
+	exec sleep infinity
+fi
+
+mkdir -p "${MT5_DATA_DIR}"
+
+echo "[entrypoint] Starting MetaTrader 5 with WINEPREFIX=${WINEPREFIX}"
+exec xvfb-run -a wine "${EXE}" /portable

--- a/infra/mt5/install_mt5.sh
+++ b/infra/mt5/install_mt5.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${WINEPREFIX:=/data/wine}"
+: "${WINEARCH:=win64}"
+
+mkdir -p "$WINEPREFIX"
+
+# Initialize Wine prefix (may fail harmlessly during build)
+wineboot -u || true
+
+TMP_DIR=/tmp/mt5
+mkdir -p "$TMP_DIR"
+cd "$TMP_DIR"
+
+MT5_URLS=(
+	"https://download.mql5.com/cdn/web/metaquotes.software.corp/mt5/mt5setup.exe"
+	"https://download.mql5.com/cdn/web/metaquotes.software.corp/mt5/MetaTrader5Setup.exe"
+)
+
+rm -f mt5setup.exe || true
+for url in "${MT5_URLS[@]}"; do
+	if wget -q -O mt5setup.exe "$url"; then
+		break
+	fi
+	done
+
+if [ ! -s mt5setup.exe ]; then
+	echo "[install_mt5] Failed to download MT5 setup" >&2
+	exit 1
+fi
+
+# Try silent install variants under Xvfb
+set +e
+xvfb-run -a wine mt5setup.exe /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /SP- /DIR="C:\\Program Files\\MetaTrader 5"
+STATUS=$?
+if [ $STATUS -ne 0 ]; then
+	xvfb-run -a wine mt5setup.exe /silent
+	STATUS=$?
+fi
+if [ $STATUS -ne 0 ]; then
+	xvfb-run -a wine mt5setup.exe
+	STATUS=$?
+fi
+set -e
+
+sleep 5
+
+if [ ! -d "$WINEPREFIX/drive_c/Program Files/MetaTrader 5" ] && [ ! -d "$WINEPREFIX/drive_c/Program Files/MetaTrader 5 Trading Platform" ]; then
+	echo "[install_mt5] MT5 installation folder not found" >&2
+	exit 1
+fi
+
+echo "[install_mt5] MT5 installation completed"


### PR DESCRIPTION
Adds Docker containerization for MetaTrader 5 (MT5) with Wine to ensure updates persist across restarts.

The previous setup for MT5 in a container/VM suffered from a loop where updates were downloaded but lost upon restart. This PR addresses that by baking a recent MT5 installer into the image and configuring persistent volumes for the installation, data, and Wine prefix, allowing updates to be retained.

---
<a href="https://cursor.com/background-agent?bcId=bc-e51986e1-b0ad-437d-97db-f94956af5c3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e51986e1-b0ad-437d-97db-f94956af5c3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

